### PR TITLE
Move linux build temporaries into tmp folder

### DIFF
--- a/src/kaiteki/linux/CMakeLists.txt
+++ b/src/kaiteki/linux/CMakeLists.txt
@@ -45,6 +45,7 @@ apply_standard_settings(${BINARY_NAME})
 target_link_libraries(${BINARY_NAME} PRIVATE flutter)
 target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::GTK)
 add_dependencies(${BINARY_NAME} flutter_assemble)
+set_target_properties(${BINARY_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/tmp)
 
 # Generated plugin build rules, which manage building the plugins and adding
 # them to the application.


### PR DESCRIPTION
As discussed on the issue tracker, this changes the Linux build process in an attempt to avoid running into [this](https://github.com/flutter/flutter/issues/62121) flutter oddity, which currently causes the `build` folder to look like this:

```
├── ...
├── bundle/
│   ├── data/
│   ├── kaiteki   [working binary]
│   └── lib/
└── kaiteki  [broken binary]
```

With the patch applied, the broken binary is hidden in a `tmp` folder, which should (hopefully) make this whole ordeal more obvious to people who are not experienced with flutter but still want to build from source.

Tested with all Kaiteki flavors.
Closes #146.