### PR TITLE
Allow https URL in nodeinfo schema

### DIFF
--- a/src/kaiteki/lib/fediverse/instance_prober.dart
+++ b/src/kaiteki/lib/fediverse/instance_prober.dart
@@ -99,8 +99,9 @@ Future<NodeInfo?> fetchNodeInfo(String host) async {
   final supportedLink = links.firstWhere((l) {
     final rel = (l["rel"] as String).toLowerCase();
 
-    return rel == "http://nodeinfo.diaspora.software/ns/schema/2.1" ||
-        rel == "http://nodeinfo.diaspora.software/ns/schema/2.0";
+    return RegExp(
+      r'^https?:\/\/nodeinfo\.diaspora\.software\/ns\/schema\/2\.(0|1)$',
+    ).hasMatch(rel);
   });
 
   final href = supportedLink["href"] as String;


### PR DESCRIPTION
Calckey replaces the nodeinfo schema URLs with https versions (see `https://lea.pet/.well-known/nodeinfo`), which previously resulted in an error when trying to access a Calckey instance. I replaced the URL comparison with a RegExp which matches both http:// and https:// URLs.