### PR TITLE
Improved clickability of posts

### DIFF
--- a/src/kaiteki/lib/ui/shared/posts/post_widget.dart
+++ b/src/kaiteki/lib/ui/shared/posts/post_widget.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
@@ -454,6 +456,7 @@ class _PostContentWidgetState extends ConsumerState<PostContentWidget> {
         context,
         ref,
         hideReplyee: widget.hideReplyee,
+        onTextTap: () => () {},
       );
     }
 

--- a/src/kaiteki/lib/ui/shared/posts/post_widget.dart
+++ b/src/kaiteki/lib/ui/shared/posts/post_widget.dart
@@ -89,6 +89,7 @@ class _PostWidgetState extends ConsumerState<PostWidget> {
             _post.repeatOf!,
             showActions: widget.showActions,
             wide: widget.wide,
+            onTextTap: widget.onTextTap,
           ),
         ],
       );

--- a/src/kaiteki/lib/ui/shared/posts/post_widget.dart
+++ b/src/kaiteki/lib/ui/shared/posts/post_widget.dart
@@ -42,6 +42,7 @@ class PostWidget extends ConsumerStatefulWidget {
   final bool hideReplyee;
   final bool hideAvatar;
   final bool expand;
+  final Function()? onTextTap;
 
   const PostWidget(
     this.post, {
@@ -52,6 +53,7 @@ class PostWidget extends ConsumerStatefulWidget {
     this.hideReplyee = false,
     this.hideAvatar = false,
     this.expand = false,
+    this.onTextTap,
   });
 
   @override
@@ -105,6 +107,7 @@ class _PostWidgetState extends ConsumerState<PostWidget> {
       PostContentWidget(
         post: _post,
         hideReplyee: widget.hideReplyee,
+        onTextTap: widget.onTextTap,
       ),
       if (_post.embeds.isNotEmpty)
         Card(
@@ -432,11 +435,13 @@ class _PostWidgetState extends ConsumerState<PostWidget> {
 class PostContentWidget extends ConsumerStatefulWidget {
   final Post post;
   final bool hideReplyee;
+  final Function()? onTextTap;
 
   const PostContentWidget({
     super.key,
     required this.post,
     required this.hideReplyee,
+    this.onTextTap,
   });
 
   @override
@@ -450,13 +455,14 @@ class _PostContentWidgetState extends ConsumerState<PostContentWidget> {
   @override
   Widget build(BuildContext context) {
     final post = widget.post;
+    final onTextTap = widget.onTextTap;
 
     if (post.content != null) {
       renderedContent = post.renderContent(
         context,
         ref,
         hideReplyee: widget.hideReplyee,
-        onTextTap: () => () {},
+        onTextTap: onTextTap,
       );
     }
 

--- a/src/kaiteki/lib/ui/shared/timeline.dart
+++ b/src/kaiteki/lib/ui/shared/timeline.dart
@@ -167,16 +167,22 @@ class TimelineState extends ConsumerState<Timeline> {
   Widget _buildPost(context, item, index) {
     return Consumer(
       builder: (context, ref, child) {
+        void pushPost() {
+          final accountKey = ref.read(accountProvider)!.key;
+          context.push(
+            "/@${accountKey.username}@${accountKey.host}/posts/${item.id}",
+            extra: item,
+          );
+        }
+
         return Material(
           child: InkWell(
-            onTap: () {
-              final accountKey = ref.read(accountProvider)!.key;
-              context.push(
-                "/@${accountKey.username}@${accountKey.host}/posts/${item.id}",
-                extra: item,
-              );
-            },
-            child: PostWidget(item, wide: widget.wide),
+            onTap: pushPost,
+            child: PostWidget(
+              item,
+              wide: widget.wide,
+              onTextTap: pushPost,
+            ),
           ),
         );
       },

--- a/src/kaiteki/lib/utils/extensions.dart
+++ b/src/kaiteki/lib/utils/extensions.dart
@@ -113,6 +113,7 @@ extension PostExtensions on Post {
     BuildContext context,
     WidgetRef ref, {
     bool hideReplyee = false,
+    Function()? onTextTap,
   }) {
     final replyee = replyToUser?.data;
     return const TextRenderer().render(
@@ -126,6 +127,7 @@ extension PostExtensions on Post {
             UserReference.handle(replyee.username, replyee.host)
         ],
       ),
+      onTextTap: onTextTap,
       onUserClick: (reference) => resolveAndOpenUser(reference, context, ref),
     );
   }

--- a/src/kaiteki/lib/utils/text/text_renderer.dart
+++ b/src/kaiteki/lib/utils/text/text_renderer.dart
@@ -158,7 +158,9 @@ class TextRenderer {
       text: element.text,
       style: element.getFlutterTextStyle(context),
       children: childrenSpans,
-      recognizer: TapGestureRecognizer()..onTap = onTextTap,
+      recognizer: onTextTap != null
+          ? (TapGestureRecognizer()..onTap = onTextTap)
+          : null,
     );
 
     if (element.style?.blur == true) {

--- a/src/kaiteki/lib/utils/text/text_renderer.dart
+++ b/src/kaiteki/lib/utils/text/text_renderer.dart
@@ -38,6 +38,7 @@ class TextRenderer {
     BuildContext context,
     String text, {
     TextContext? textContext,
+    Function()? onTextTap,
     required Function(UserReference reference) onUserClick,
   }) {
     final renderedElements = renderChildren(
@@ -46,6 +47,7 @@ class TextRenderer {
       textContext ?? TextContext(),
       Theme.of(context).ktkTextTheme,
       onUserClick: onUserClick,
+      onTextTap: onTextTap,
     );
     return TextSpan(children: renderedElements.toList(growable: false));
   }
@@ -56,6 +58,7 @@ class TextRenderer {
     TextContext textContext,
     KaitekiTextTheme? theme, {
     required Function(UserReference) onUserClick,
+    Function()? onTextTap,
   }) {
     final childrenSpans = renderChildren(
       context,
@@ -63,10 +66,11 @@ class TextRenderer {
       textContext,
       theme,
       onUserClick: onUserClick,
+      onTextTap: onTextTap,
     );
 
     if (element is TextElement) {
-      return renderText(context, element, childrenSpans);
+      return renderText(context, element, childrenSpans, onTextTap);
     }
     if (element is LinkElement) {
       return renderLink(
@@ -120,6 +124,7 @@ class TextRenderer {
     TextContext textContext,
     KaitekiTextTheme? theme, {
     required Function(UserReference reference) onUserClick,
+    Function()? onTextTap,
   }) {
     final spans = <InlineSpan>[];
 
@@ -131,6 +136,7 @@ class TextRenderer {
           textContext,
           theme,
           onUserClick: onUserClick,
+          onTextTap: onTextTap,
         );
 
         if (element != null) {
@@ -146,11 +152,13 @@ class TextRenderer {
     BuildContext context,
     TextElement element,
     List<InlineSpan>? childrenSpans,
+    Function()? onTextTap,
   ) {
     final InlineSpan span = TextSpan(
       text: element.text,
       style: element.getFlutterTextStyle(context),
       children: childrenSpans,
+      recognizer: TapGestureRecognizer()..onTap = onTextTap,
     );
 
     if (element.style?.blur == true) {


### PR DESCRIPTION
Post opens now their respective conversation screen when you press on normal text while preserving the possibility to copy text. Searching the right place to tap should now be a problem of the past, especially on mobile.
No implementation for emojis yet, as I didn't find a nice way to get it working.