### PR TITLE
fix(linux): initialize libhandy

### DIFF
--- a/src/kaiteki/linux/my_application.cc
+++ b/src/kaiteki/linux/my_application.cc
@@ -46,8 +46,15 @@ static void my_application_activate(GApplication *application)
   gtk_widget_grab_focus(GTK_WIDGET(view));
 }
 
+static void my_application_startup(GApplication *application)
+{
+  G_APPLICATION_CLASS(my_application_parent_class)->startup(application);
+  hdy_init();
+}
+
 static void my_application_class_init(MyApplicationClass *klass)
 {
+  G_APPLICATION_CLASS(klass)->startup = my_application_startup;
   G_APPLICATION_CLASS(klass)->activate = my_application_activate;
 }
 


### PR DESCRIPTION
libhandy needs to be initialized before use:

prior to this PR:

[Screencast from 2023-05-19 17-35-27.webm](https://github.com/Kaiteki-Fedi/Kaiteki/assets/18014039/7159b3f1-f783-4491-b573-b3ca43c1084f)

notice the lack of rounded corners and me being unable to move the window

after this PR:

[Screencast from 2023-05-19 17-34-24.webm](https://github.com/Kaiteki-Fedi/Kaiteki/assets/18014039/4792cb2c-70d0-47df-8fa7-5c5cf41bc75d)
