### PR TITLE
Fix opening notifications when "Show read notifications" is set

### DIFF
--- a/src/kaiteki/lib/ui/main/pages/notifications.dart
+++ b/src/kaiteki/lib/ui/main/pages/notifications.dart
@@ -97,7 +97,7 @@ class _NotificationsPageState extends ConsumerState<NotificationsPage> {
         final notifications =
             ref.read(notificationServiceProvider(account.key)).valueOrNull;
         if (notifications != null &&
-            notifications.any((e) => e.unread ?? false)) {
+            !notifications.any((e) => e.unread ?? true)) {
           return 1;
         }
       }


### PR DESCRIPTION
Opening the notifications tab with "Show read notifications (when no unread)" setting enabled would open the other tab.

When unread notifications were available, Kaiteki would open the read tab.

When there are no unread notifications, Kaiteki would open the unread tab.

In the method _getInitialIndex, "read notifications" is tab 0 and "unread notifications" is tab 1.

Previously, _getInitialIndex checked for any notification that was read and returned 1.

Instead, check if any notifications are unread and if not, send the user to the read tab.