### PR TITLE
fix: ignore ds_store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ doc/api/
 GeneratedPluginRegistrant.*
 generated_plugin_registrant.*
 src/kaiteki/lib/fediverse/backends/twitter/keys.dart
+src/.DS_Store
+.DS_Store

--- a/src/kaiteki/lib/fediverse/backends/misskey/adapter.c.dart
+++ b/src/kaiteki/lib/fediverse/backends/misskey/adapter.c.dart
@@ -232,7 +232,7 @@ extension KaitekiNotificationExtension on misskey.Notification {
       type: misskeyNotificationTypeRosetta.getRight(type),
       user: user?.toKaiteki(localHost),
       post: note?.toKaiteki(localHost),
-      unread: !isRead,
+      unread: !isRead!,
     );
   }
 }


### PR DESCRIPTION
This happens sometimes when working with apple distribution platforms best to avoid adding these junk files to the repo.