### PR TITLE
fix mastodon post url search

### DIFF
--- a/src/kaiteki_core/lib/src/social/backends/mastodon/shared_adapter.dart
+++ b/src/kaiteki_core/lib/src/social/backends/mastodon/shared_adapter.dart
@@ -424,7 +424,7 @@ abstract class SharedMastodonAdapter<T extends MastodonClient>
 
   @override
   Future<SearchResults> search(String query) async {
-    final results = await client.search(query);
+    final results = await client.search(query, resolve: true);
 
     return SearchResults(
       users: results.accounts.map((a) => a.toKaiteki(instance)).toList(),


### PR DESCRIPTION
When I paste a url to a post in the search box, I expect the post to be found. This pr fixes it