### PR TITLE
Properly handle no previous sessions

### DIFF
--- a/packages/kaiteki/lib/main.dart
+++ b/packages/kaiteki/lib/main.dart
@@ -99,6 +99,12 @@ Stream<StartupState> _startup(SharedPreferences sharedPreferences) async* {
       .restoreSessions(priorityAccount: priorityAccount)
       .asBroadcastStream();
 
+  if (await sessions.isEmpty) {
+    // If there are no active user sessions (first launch), yield appropriate state
+    yield const StartupStarting();
+    return;
+  }
+
   await for (final account in sessions) {
     yield StartupSignIn(account);
 


### PR DESCRIPTION
Properly handle no previous sessions. Prevents a StateError exception on first load.